### PR TITLE
Dynamic lighting

### DIFF
--- a/Broken Mirror v2.vcxproj
+++ b/Broken Mirror v2.vcxproj
@@ -40,6 +40,7 @@
     <ClInclude Include="Engine\flow.h" />
     <ClInclude Include="Engine\font.h" />
     <ClInclude Include="Engine\imageHandler.h" />
+    <ClInclude Include="Engine\light.h" />
     <ClInclude Include="Engine\maps.h" />
     <ClInclude Include="Engine\menu.h" />
     <ClInclude Include="Engine\noise.h" />

--- a/Broken Mirror v2.vcxproj.filters
+++ b/Broken Mirror v2.vcxproj.filters
@@ -119,6 +119,9 @@
     <ClInclude Include="Engine\box.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="Engine\light.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <None Include="notes.md" />

--- a/Engine/box.h
+++ b/Engine/box.h
@@ -104,11 +104,12 @@ public:
 
 	void emptyContainers()
 	{
+		if (!spriteContainer.empty()) { spriteContainer.clear(); }
+		if (!spriteContainerBlack.empty()) { spriteContainerBlack.clear(); }
+
 		borderBlack.resize(0);
 		border.resize(0);
 		background.resize(0);
-		spriteContainer.clear();
-		spriteContainerBlack.clear();
 	}
 	void createBackground(sf::Vector2f startPosition, int width, int height)
 	{

--- a/Engine/imageHandler.cpp
+++ b/Engine/imageHandler.cpp
@@ -5,6 +5,12 @@ ImageHandler::ImageHandler()
 {
     zDepth = 10;
 
+    lights_shader.loadFromMemory(lightFrag, sf::Shader::Fragment);
+    //sf::RenderStates states;
+    //states.shader = &lights_shader;
+    //states.blendMode = sf::BlendMultiply;
+    normals_shader.loadFromMemory(normalsFrag, sf::Shader::Fragment);
+
     if (!tileImage.loadFromFile("C:/Users/Windows/Documents/Github/Broken Mirror v2/BM/ImageResources/TILE.bmp"))
     {
         tileImage.loadFromFile(getLocalPath() + "/ImageResources/TILE.bmp");

--- a/Engine/imageHandler.cpp
+++ b/Engine/imageHandler.cpp
@@ -52,6 +52,8 @@ ImageHandler::ImageHandler()
     tilemapRenderFront.create(intify(sceneSize.x), intify(sceneSize.y));
     normalsRender.create(intify(sceneSize.x), intify(sceneSize.y));
 
+    tilemapWindowFront.setSize(sf::Vector2f(floatify(sceneSize.x), floatify(sceneSize.y)));
+
     this->loadWestKagar();
 
 }
@@ -60,6 +62,7 @@ void ImageHandler::loadWestKagar()
 {
     tilemapRenderBack.clear();
     tilemapRenderFront.clear(sf::Color(0, 0, 0, 0));
+    //tilemapRenderFront.clear();
     normalsRender.clear();
     tilemapVector.clear();
     tilemapNormalVector.clear();
@@ -249,6 +252,9 @@ void ImageHandler::loadWestKagar()
     normalsRender.display();
     tilemapRenderBack.display();
     tilemapRenderFront.display();
+
+    tilemapWindowFront.setTexture(&tilemapRenderFront.getTexture());
+    tilemapWindowFront.setScale(pairF(View::getPixelSize(), View::getPixelSize()));
 }
 
 // Checks the lowest map for allowable movement.

--- a/Engine/imageHandler.cpp
+++ b/Engine/imageHandler.cpp
@@ -13,11 +13,16 @@ ImageHandler::ImageHandler()
 
     if (!tileImage.loadFromFile("C:/Users/Windows/Documents/Github/Broken Mirror v2/BM/ImageResources/TILE.bmp"))
     {
-        tileImage.loadFromFile(getLocalPath() + "/ImageResources/TILE.bmp");
+        tileImage.loadFromFile(getLocalPath() + "../ImageResources/TILE.bmp");
     }
     tileImage.createMaskFromColor(sf::Color(237, 28, 36, 255), 0);
     tileImage.createMaskFromColor(sf::Color(13, 103, 148, 255), 150);
     tileImage.createMaskFromColor(sf::Color(26, 98, 138, 255), 200);
+
+    if (!tileNormalImage.loadFromFile("C:/Users/Windows/Documents/Github/Broken Mirror v2/BM/ImageResources/TILE_NORMAL.bmp"))
+    {
+        tileNormalImage.loadFromFile(getLocalPath() + "../ImageResources/TILE_NORMAL.bmp");
+    }
 
     tilemapVector.push_back(&tileMapA);
     tilemapVector.push_back(&tileMapB);
@@ -30,6 +35,17 @@ ImageHandler::ImageHandler()
     tilemapVector.push_back(&tileMapI);
     tilemapVector.push_back(&tileMapJ);
 
+    tilemapNormalVector.push_back(&tileMapNormalA);
+    tilemapNormalVector.push_back(&tileMapNormalB);
+    tilemapNormalVector.push_back(&tileMapNormalC);
+    tilemapNormalVector.push_back(&tileMapNormalD);
+    tilemapNormalVector.push_back(&tileMapNormalE);
+    tilemapNormalVector.push_back(&tileMapNormalF);
+    tilemapNormalVector.push_back(&tileMapNormalG);
+    tilemapNormalVector.push_back(&tileMapNormalH);
+    tilemapNormalVector.push_back(&tileMapNormalI);
+    tilemapNormalVector.push_back(&tileMapNormalJ);
+
     sf::Vector2u sceneSize = View::getSceneSize();
     tilemapRenderBack.create(intify(sceneSize.x), intify(sceneSize.y));
     tilemapRenderBack.clear(sf::Color::Black);
@@ -39,6 +55,11 @@ ImageHandler::ImageHandler()
     tilemapRenderFront.clear(sf::Color::Transparent);
     tilemapWindowFront.setSize(sf::Vector2f(floatify(sceneSize.x), floatify(sceneSize.y)));
 
+    lightRender.create(intify(sceneSize.x), intify(sceneSize.y));
+    normalsRender.create(intify(sceneSize.x), intify(sceneSize.y));
+    diffuseRender.create(intify(sceneSize.x), intify(sceneSize.y));
+    back.create(intify(sceneSize.x), intify(sceneSize.y));
+
     this->loadWestKagar();
 
 }
@@ -47,6 +68,10 @@ void ImageHandler::loadWestKagar()
 {
     tilemapRenderBack.clear(sf::Color(0, 0, 0, 255));
     tilemapRenderFront.clear(sf::Color(0, 0, 0, 0));
+    normalsRender.clear();
+    diffuseRender.clear();
+    lightRender.clear();
+    back.clear();
 
     for (int i = 0; i < zDepth; i++)
     {
@@ -54,6 +79,13 @@ void ImageHandler::loadWestKagar()
         {
         case 0:
             tilemapVector[i]->createMasterTile
+            (
+                westKagar00a, westKagar10a, westKagar20a, westKagar30a,
+                westKagar01a, westKagar11a, westKagar21a, westKagar31a,
+                westKagar02a, westKagar12a, westKagar22a, westKagar32a,
+                westKagar03a, westKagar13a, westKagar23a, westKagar33a
+            );
+            tilemapNormalVector[i]->createMasterTile
             (
                 westKagar00a, westKagar10a, westKagar20a, westKagar30a,
                 westKagar01a, westKagar11a, westKagar21a, westKagar31a,
@@ -69,9 +101,23 @@ void ImageHandler::loadWestKagar()
                 westKagar02b, westKagar12b, westKagar22b, westKagar32b,
                 westKagar03b, westKagar13b, westKagar23b, westKagar33b
             );
+            tilemapNormalVector[i]->createMasterTile
+            (
+                westKagar00b, westKagar10b, westKagar20b, westKagar30b,
+                westKagar01b, westKagar11b, westKagar21b, westKagar31b,
+                westKagar02b, westKagar12b, westKagar22b, westKagar32b,
+                westKagar03b, westKagar13b, westKagar23b, westKagar33b
+            );
             break;
         case 2:
             tilemapVector[i]->createMasterTile
+            (
+                westKagar00c, westKagar10c, westKagar20c, westKagar30c,
+                westKagar01c, westKagar11c, westKagar21c, westKagar31c,
+                westKagar02c, westKagar12c, westKagar22c, westKagar32c,
+                westKagar03c, westKagar13c, westKagar23c, westKagar33c
+            );
+            tilemapNormalVector[i]->createMasterTile
             (
                 westKagar00c, westKagar10c, westKagar20c, westKagar30c,
                 westKagar01c, westKagar11c, westKagar21c, westKagar31c,
@@ -87,9 +133,23 @@ void ImageHandler::loadWestKagar()
                 westKagar02d, westKagar12d, westKagar22d, westKagar32d,
                 westKagar03d, westKagar13d, westKagar23d, westKagar33d
             ); 
+            tilemapNormalVector[i]->createMasterTile
+            (
+                westKagar00d, westKagar10d, westKagar20d, westKagar30d,
+                westKagar01d, westKagar11d, westKagar21d, westKagar31d,
+                westKagar02d, westKagar12d, westKagar22d, westKagar32d,
+                westKagar03d, westKagar13d, westKagar23d, westKagar33d
+            );
             break;
         case 4:
             tilemapVector[i]->createMasterTile
+            (
+                westKagar00e, westKagar10e, westKagar20e, westKagar30e,
+                westKagar01e, westKagar11e, westKagar21e, westKagar31e,
+                westKagar02e, westKagar12e, westKagar22e, westKagar32e,
+                westKagar03e, westKagar13e, westKagar23e, westKagar33e
+            );
+            tilemapNormalVector[i]->createMasterTile
             (
                 westKagar00e, westKagar10e, westKagar20e, westKagar30e,
                 westKagar01e, westKagar11e, westKagar21e, westKagar31e,
@@ -105,9 +165,23 @@ void ImageHandler::loadWestKagar()
                 westKagar02f, westKagar12f, westKagar22f, westKagar32f,
                 westKagar03f, westKagar13f, westKagar23f, westKagar33f
             );
+            tilemapNormalVector[i]->createMasterTile
+            (
+                westKagar00f, westKagar10f, westKagar20f, westKagar30f,
+                westKagar01f, westKagar11f, westKagar21f, westKagar31f,
+                westKagar02f, westKagar12f, westKagar22f, westKagar32f,
+                westKagar03f, westKagar13f, westKagar23f, westKagar33f
+            );
             break;
         case 6:
             tilemapVector[i]->createMasterTile
+            (
+                westKagar00g, westKagar10g, westKagar20g, westKagar30g,
+                westKagar01g, westKagar11g, westKagar21g, westKagar31g,
+                westKagar02g, westKagar12g, westKagar22g, westKagar32g,
+                westKagar03g, westKagar13g, westKagar23g, westKagar33g
+            );
+            tilemapNormalVector[i]->createMasterTile
             (
                 westKagar00g, westKagar10g, westKagar20g, westKagar30g,
                 westKagar01g, westKagar11g, westKagar21g, westKagar31g,
@@ -123,9 +197,23 @@ void ImageHandler::loadWestKagar()
                 westKagar02h, westKagar12h, westKagar22h, westKagar32h,
                 westKagar03h, westKagar13h, westKagar23h, westKagar33h
             );
+            tilemapNormalVector[i]->createMasterTile
+            (
+                westKagar00h, westKagar10h, westKagar20h, westKagar30h,
+                westKagar01h, westKagar11h, westKagar21h, westKagar31h,
+                westKagar02h, westKagar12h, westKagar22h, westKagar32h,
+                westKagar03h, westKagar13h, westKagar23h, westKagar33h
+            );
             break;
         case 8:
             tilemapVector[i]->createMasterTile
+            (
+                westKagar00i, westKagar10i, westKagar20i, westKagar30i,
+                westKagar01i, westKagar11i, westKagar21i, westKagar31i,
+                westKagar02i, westKagar12i, westKagar22i, westKagar32i,
+                westKagar03i, westKagar13i, westKagar23i, westKagar33i
+            );
+            tilemapNormalVector[i]->createMasterTile
             (
                 westKagar00i, westKagar10i, westKagar20i, westKagar30i,
                 westKagar01i, westKagar11i, westKagar21i, westKagar31i,
@@ -141,30 +229,40 @@ void ImageHandler::loadWestKagar()
                 westKagar02j, westKagar12j, westKagar22j, westKagar32j,
                 westKagar03j, westKagar13j, westKagar23j, westKagar33j
             );
+            tilemapNormalVector[i]->createMasterTile
+            (
+                westKagar00j, westKagar10j, westKagar20j, westKagar30j,
+                westKagar01j, westKagar11j, westKagar21j, westKagar31j,
+                westKagar02j, westKagar12j, westKagar22j, westKagar32j,
+                westKagar03j, westKagar13j, westKagar23j, westKagar33j
+            );
             break;
         default:
             break;
         }
 
         tilemapVector[i]->load(tileImage, sf::Vector2u(32, 32), 96, 56);
+        tilemapNormalVector[i]->load(tileNormalImage, sf::Vector2u(32, 32), 96, 56);
 
         if (i < 5)
         {
             tilemapRenderBack.draw(*tilemapVector[i]);
+            normalsRender.draw(*tilemapNormalVector[i]);
         }
         else
         {
             tilemapRenderFront.draw(*tilemapVector[i]);
         }
     }
+    normalsRender.display();
 
     tilemapRenderBack.display();
     tilemapRenderFront.display();
-    tilemapWindowBack.setTexture(&tilemapRenderBack.getTexture());
+    //tilemapWindowBack.setTexture(&tilemapRenderBack.getTexture());
     tilemapWindowFront.setTexture(&tilemapRenderFront.getTexture());
     //tilemapWindowFront.setFillColor(sf::Color(255, 255, 255, 155)); //neat, global transparency.
     int pixelSize{ getPixelSize() };
-    tilemapWindowBack.setScale(sf::Vector2f(pixelSize, pixelSize));
+    //tilemapWindowBack.setScale(sf::Vector2f(pixelSize, pixelSize));
     tilemapWindowFront.setScale(sf::Vector2f(pixelSize, pixelSize));
 }
 

--- a/Engine/imageHandler.cpp
+++ b/Engine/imageHandler.cpp
@@ -49,17 +49,8 @@ ImageHandler::ImageHandler()
 
     sf::Vector2u sceneSize = View::getSceneSize();
     tilemapRenderBack.create(intify(sceneSize.x), intify(sceneSize.y));
-    tilemapRenderBack.clear(sf::Color::Black);
-    tilemapWindowBack.setSize(sf::Vector2f(floatify(sceneSize.x), floatify(sceneSize.y)));
-
     tilemapRenderFront.create(intify(sceneSize.x), intify(sceneSize.y));
-    tilemapRenderFront.clear(sf::Color::Transparent);
-    tilemapWindowFront.setSize(sf::Vector2f(floatify(sceneSize.x), floatify(sceneSize.y)));
-
-    lightRender.create(intify(sceneSize.x), intify(sceneSize.y));
     normalsRender.create(intify(sceneSize.x), intify(sceneSize.y));
-    diffuseRender.create(intify(sceneSize.x), intify(sceneSize.y));
-    back.create(intify(sceneSize.x), intify(sceneSize.y));
 
     this->loadWestKagar();
 
@@ -70,9 +61,6 @@ void ImageHandler::loadWestKagar()
     tilemapRenderBack.clear();
     tilemapRenderFront.clear(sf::Color(0, 0, 0, 0));
     normalsRender.clear();
-    diffuseRender.clear();
-    lightRender.clear();
-    back.clear();
     tilemapVector.clear();
     tilemapNormalVector.clear();
 
@@ -255,18 +243,12 @@ void ImageHandler::loadWestKagar()
         else
         {
             tilemapRenderFront.draw(*tilemapVector[i]);
+            //normalsRender.draw(*tilemapNormalVector[i]);
         }
     }
     normalsRender.display();
-
     tilemapRenderBack.display();
     tilemapRenderFront.display();
-    //tilemapWindowBack.setTexture(&tilemapRenderBack.getTexture());
-    //tilemapWindowFront.setTexture(&tilemapRenderFront.getTexture());
-    //tilemapWindowFront.setFillColor(sf::Color(255, 255, 255, 155)); //neat, global transparency.
-    int pixelSize{ getPixelSize() };
-    //tilemapWindowBack.setScale(sf::Vector2f(pixelSize, pixelSize));
-    //tilemapWindowFront.setScale(sf::Vector2f(pixelSize, pixelSize));
 }
 
 // Checks the lowest map for allowable movement.

--- a/Engine/imageHandler.cpp
+++ b/Engine/imageHandler.cpp
@@ -19,10 +19,11 @@ ImageHandler::ImageHandler()
     tileImage.createMaskFromColor(sf::Color(13, 103, 148, 255), 150);
     tileImage.createMaskFromColor(sf::Color(26, 98, 138, 255), 200);
 
-    if (!tileNormalImage.loadFromFile("C:/Users/Windows/Documents/Github/Broken Mirror v2/BM/ImageResources/TILE_NORMAL.bmp"))
+    if (!tileNormalImage.loadFromFile("C:/Users/Windows/Documents/Github/Broken Mirror v2/BM/ImageResources/TILE_NORMAL3.bmp"))
     {
-        tileNormalImage.loadFromFile(getLocalPath() + "../ImageResources/TILE_NORMAL.bmp");
+        tileNormalImage.loadFromFile(getLocalPath() + "../ImageResources/TILE_NORMAL3.bmp");
     }
+    tileNormalImage.createMaskFromColor(sf::Color(255, 255, 255, 255), 0);
 
     tilemapVector.push_back(&tileMapA);
     tilemapVector.push_back(&tileMapB);
@@ -66,12 +67,14 @@ ImageHandler::ImageHandler()
 
 void ImageHandler::loadWestKagar()
 {
-    tilemapRenderBack.clear(sf::Color(0, 0, 0, 255));
+    tilemapRenderBack.clear();
     tilemapRenderFront.clear(sf::Color(0, 0, 0, 0));
     normalsRender.clear();
     diffuseRender.clear();
     lightRender.clear();
     back.clear();
+    tilemapVector.clear();
+    tilemapNormalVector.clear();
 
     for (int i = 0; i < zDepth; i++)
     {
@@ -259,11 +262,11 @@ void ImageHandler::loadWestKagar()
     tilemapRenderBack.display();
     tilemapRenderFront.display();
     //tilemapWindowBack.setTexture(&tilemapRenderBack.getTexture());
-    tilemapWindowFront.setTexture(&tilemapRenderFront.getTexture());
+    //tilemapWindowFront.setTexture(&tilemapRenderFront.getTexture());
     //tilemapWindowFront.setFillColor(sf::Color(255, 255, 255, 155)); //neat, global transparency.
     int pixelSize{ getPixelSize() };
     //tilemapWindowBack.setScale(sf::Vector2f(pixelSize, pixelSize));
-    tilemapWindowFront.setScale(sf::Vector2f(pixelSize, pixelSize));
+    //tilemapWindowFront.setScale(sf::Vector2f(pixelSize, pixelSize));
 }
 
 // Checks the lowest map for allowable movement.

--- a/Engine/imageHandler.cpp
+++ b/Engine/imageHandler.cpp
@@ -6,8 +6,8 @@ ImageHandler::ImageHandler()
     zDepth = 10;
 
     back.lightShader.loadFromMemory(lightFrag, sf::Shader::Fragment);
-    front.lightShader.loadFromMemory(lightFrag, sf::Shader::Fragment);
     back.normalShader.loadFromMemory(normalsFrag, sf::Shader::Fragment);
+    front.lightShader.loadFromMemory(lightFrag, sf::Shader::Fragment);
     front.normalShader.loadFromMemory(normalsFrag, sf::Shader::Fragment);
 
     if (!tileImage.loadFromFile("C:/Users/Windows/Documents/Github/Broken Mirror v2/BM/ImageResources/TILE.bmp"))
@@ -47,12 +47,16 @@ ImageHandler::ImageHandler()
     tilemapNormalVector.push_back(&tileMapNormalJ);
 
     sf::Vector2u sceneSize = View::getSceneSize();
+
     back.tilemapRender.create(intify(sceneSize.x), intify(sceneSize.y));
-    front.tilemapRender.create(intify(sceneSize.x), intify(sceneSize.y));
     back.normalRender.create(intify(sceneSize.x), intify(sceneSize.y));
-    front.normalRender.create(intify(sceneSize.x), intify(sceneSize.y));
     back.sceneRender.create(intify(sceneSize.x), intify(sceneSize.y));
+    front.tilemapRender.create(intify(sceneSize.x), intify(sceneSize.y));
+    front.normalRender.create(intify(sceneSize.x), intify(sceneSize.y));
     front.sceneRender.create(intify(sceneSize.x), intify(sceneSize.y));
+
+    back.lightRender.create(View::getScreenSize().x, View::getScreenSize().y);
+    front.lightRender.create(View::getScreenSize().x, View::getScreenSize().y);
 
     this->loadWestKagar();
 }
@@ -62,7 +66,6 @@ void ImageHandler::loadWestKagar()
     back.sceneRender.clear();
     back.tilemapRender.clear();
     back.normalRender.clear();
-
     front.sceneRender.clear(sf::Color::Transparent);
     front.tilemapRender.clear(sf::Color::Transparent);
     front.normalRender.clear();
@@ -255,7 +258,6 @@ void ImageHandler::loadWestKagar()
 
     back.normalRender.display();
     back.tilemapRender.display();
-
     front.normalRender.display();
     front.tilemapRender.display();
 
@@ -268,9 +270,7 @@ void ImageHandler::loadLights(RenderPipeline &scene)
     int width{ intify(View::getSceneSize().x * View::getPixelSize()) };
     int height{ intify(View::getSceneSize().y * View::getPixelSize()) };
 
-    // Create and clear to neutral color
-    lightRender.create(View::getScreenSize().x, View::getScreenSize().y);
-    lightRender.clear();
+    scene.lightRender.clear();
 
     scene.pass_normals.create(width, height);
     scene.pass_normals.clear(sf::Color(128, 128, 255));
@@ -289,7 +289,7 @@ void ImageHandler::loadLights(RenderPipeline &scene)
 
     // Light Pass, renders every light into a rendertexture
     scene.lightShader.setUniform("resolution", sf::Vector2f(View::getScreenSize().x, View::getScreenSize().y));
-    scene.lightShader.setUniform("sampler_light", lightRender.getTexture());
+    scene.lightShader.setUniform("sampler_light", scene.lightRender.getTexture());
     scene.lightShader.setUniform("ambient_intensity", scene.light.ambientIntensity);
     scene.lightShader.setUniform("falloff", scene.light.falloff);
     scene.lightShader.setUniform("light_color", scene.light.color);
@@ -302,14 +302,14 @@ void ImageHandler::loadLights(RenderPipeline &scene)
 void ImageHandler::drawScene(RenderPipeline& scene)
 {
     // Clear render and draw diffuse scene
-    scene.sceneRender.clear();
+    scene.sceneRender.clear(sf::Color::Transparent);
     scene.sceneRender.draw(scene.tilemapRenderSprite);
 
     // Draw light shader over diffuse scene, blended
     sf::RenderStates renderStates;
     renderStates.blendMode = sf::BlendMultiply;
     renderStates.shader = &scene.lightShader;
-    back.sceneRender.draw(back.tilemapRenderSprite, renderStates);
+    scene.sceneRender.draw(scene.tilemapRenderSprite, renderStates);
 
     // Display scene
     scene.sceneRender.display();

--- a/Engine/imageHandler.cpp
+++ b/Engine/imageHandler.cpp
@@ -19,9 +19,9 @@ ImageHandler::ImageHandler()
     tileImage.createMaskFromColor(sf::Color(13, 103, 148, 255), 150);
     tileImage.createMaskFromColor(sf::Color(26, 98, 138, 255), 200);
 
-    if (!tileNormalImage.loadFromFile("C:/Users/Windows/Documents/Github/Broken Mirror v2/BM/ImageResources/TILE_NORMAL3.bmp"))
+    if (!tileNormalImage.loadFromFile("C:/Users/Windows/Documents/Github/Broken Mirror v2/BM/ImageResources/TILE-NORMAL.bmp"))
     {
-        tileNormalImage.loadFromFile(getLocalPath() + "../ImageResources/TILE_NORMAL3.bmp");
+        tileNormalImage.loadFromFile(getLocalPath() + "../ImageResources/TILE-NORMAL.bmp");
     }
     tileNormalImage.createMaskFromColor(sf::Color(255, 255, 255, 255), 0);
 

--- a/Engine/imageHandler.h
+++ b/Engine/imageHandler.h
@@ -54,8 +54,21 @@ public:
     TileMap tileMapH;
     TileMap tileMapI;
     TileMap tileMapJ;
+
+	TileMap tileMapNormalA;
+	TileMap tileMapNormalB;
+	TileMap tileMapNormalC;
+	TileMap tileMapNormalD;
+	TileMap tileMapNormalE;
+	TileMap tileMapNormalF;
+	TileMap tileMapNormalG;
+	TileMap tileMapNormalH;
+	TileMap tileMapNormalI;
+	TileMap tileMapNormalJ;
+
     sf::Image tileImage;
     std::vector<TileMap*> tilemapVector;
+    std::vector<TileMap*> tilemapNormalVector;
 
     sf::RenderTexture tilemapRenderBack;//
     sf::RenderTexture tilemapRenderFront;
@@ -66,10 +79,14 @@ public:
 	sf::Shader lights_shader;
 	sf::Shader normals_shader;
 
-	sf::Texture normalMapTexture;
+	sf::Image tileNormalImage;
 	sf::RenderTexture lightRender;
 	sf::RenderTexture normalsRender;
 	sf::RenderTexture diffuseRender;
+	sf::RenderTexture back;
+
+
+	Light light;
 
     ImageHandler();
 

--- a/Engine/imageHandler.h
+++ b/Engine/imageHandler.h
@@ -3,10 +3,46 @@
 #include "view.h"
 #include "tilemap.h"
 #include "maps.h"
+#include "light.h"
 
 class ImageHandler : protected View
 {
 public:
+	const char lightFrag[897] =
+		"uniform vec2 resolution;"
+		"uniform sampler2D sampler_normal;"
+		"uniform sampler2D sampler_light;"
+		"uniform vec3 light_pos;"
+		"uniform vec3 light_color;"
+		"uniform vec3 ambient_color = vec3(0.5, 0.5, 0.5);"
+		"uniform float ambient_intensity;"
+		"uniform vec3 falloff;"
+		"void main()"
+		"{"
+		"vec2 coord = gl_TexCoord[0].xy;"
+		"vec3 normal_map = texture2D(sampler_normal, coord).rgb;"
+		"vec3 light_map = texture2D(sampler_light, coord).rgb;"
+		"vec3 lightDir = vec3((light_pos.xy - gl_FragCoord.xy) / resolution.xy, light_pos.z); "
+		"lightDir.x *= resolution.x / resolution.y;"
+		"float D = length(lightDir);"
+		"vec3 N = normalize(normal_map * 2.0 - 1.0);"
+		//"vec3 N = -1.0 * normalize(normal_map * 2.0 - 1.0);"
+		"vec3 L = normalize(lightDir.xyz);"
+		"vec3 diffuse = light_color.rgb * max(dot(N, L), 0.0);"
+		"vec3 ambient = ambient_color * ambient_intensity;"
+		"float attenuation = 1.0 / (falloff.x + (falloff.y * D) + falloff.z * D * D);"
+		"vec3 intensity = ambient + diffuse * attenuation;"
+		"gl_FragColor = vec4(light_map + intensity, 1.0);"
+		"}";
+
+	const char normalsFrag[155] =
+		"uniform sampler2D sampler_normal;"
+		"void main(void)"
+		"{"
+		"vec3 normal_map = texture2D(sampler_normal, gl_TexCoord[0].xy).rgb;"
+		"gl_FragColor = vec4(normal_map, 1.0);"
+		"}";
+
     uint8_t zDepth;
     TileMap tileMapA;
     TileMap tileMapB;
@@ -21,11 +57,19 @@ public:
     sf::Image tileImage;
     std::vector<TileMap*> tilemapVector;
 
-    sf::RenderTexture tilemapRenderBack;
+    sf::RenderTexture tilemapRenderBack;//
     sf::RenderTexture tilemapRenderFront;
     
     sf::RectangleShape tilemapWindowBack;
     sf::RectangleShape tilemapWindowFront;
+
+	sf::Shader lights_shader;
+	sf::Shader normals_shader;
+
+	sf::Texture normalMapTexture;
+	sf::RenderTexture lightRender;
+	sf::RenderTexture normalsRender;
+	sf::RenderTexture diffuseRender;
 
     ImageHandler();
 

--- a/Engine/imageHandler.h
+++ b/Engine/imageHandler.h
@@ -74,18 +74,25 @@ public:
     sf::RenderTexture tilemapRenderFront;
 
 	sf::Shader lights_shader;
-	sf::Shader normals_shader;
+	sf::Shader normals_shader_back;
+	sf::Shader normals_shader_front;
 
 	sf::Image tileNormalImage;
-	sf::RenderTexture normalsRender;
+	sf::RenderTexture normalsRenderBack;
+	sf::RenderTexture normalsRenderFront;
 
 	Light light;
 
 	sf::RenderTexture lightRender;
-	sf::RenderTexture pass_normals;
-	sf::Texture normal_map;
-	sf::Texture diffuse_map;
+	sf::RenderTexture pass_normals_back;
+	sf::RenderTexture pass_normals_front;
+	sf::Texture normal_map_back;
+	sf::Texture normal_map_front;
+	sf::Texture diffuse_map_back;
+	sf::Texture diffuse_map_front;
 	//sf::Sprite spriteT;
+	sf::RenderTexture backSceneRender;
+	sf::RenderTexture frontSceneRender;
 
     ImageHandler();
 

--- a/Engine/imageHandler.h
+++ b/Engine/imageHandler.h
@@ -10,6 +10,7 @@ struct RenderPipeline
 	sf::Shader lightShader;
 	sf::Shader normalShader;
 
+	sf::RenderTexture lightRender;
 	Light light;
 
 	sf::RenderTexture tilemapRender;
@@ -90,11 +91,13 @@ public:
 #pragma endregion
 
     uint8_t zDepth;
+
     sf::Image tileImage;
 	sf::Image tileNormalImage;
+
     std::vector<TileMap*> tilemapVector;
     std::vector<TileMap*> tilemapNormalVector;
-	sf::RenderTexture lightRender;
+
 	RenderPipeline back;
 	RenderPipeline front;
 

--- a/Engine/imageHandler.h
+++ b/Engine/imageHandler.h
@@ -72,24 +72,24 @@ public:
 
     sf::RenderTexture tilemapRenderBack;//
     sf::RenderTexture tilemapRenderFront;
-    
-    sf::RectangleShape tilemapWindowBack;
-    sf::RectangleShape tilemapWindowFront;
 
 	sf::Shader lights_shader;
 	sf::Shader normals_shader;
 
 	sf::Image tileNormalImage;
-	sf::RenderTexture lightRender;
 	sf::RenderTexture normalsRender;
-	sf::RenderTexture diffuseRender;
-	sf::RenderTexture back;
-
 
 	Light light;
+
+	sf::RenderTexture lightRender;
+	sf::RenderTexture pass_normals;
+	sf::Texture normal_map;
+	sf::Texture diffuse_map;
+	//sf::Sprite spriteT;
 
     ImageHandler();
 
     void loadWestKagar();
+	void loadLights();
     bool checkBounds(int direction, sf::Vector2i position);
 };

--- a/Engine/imageHandler.h
+++ b/Engine/imageHandler.h
@@ -5,9 +5,30 @@
 #include "maps.h"
 #include "light.h"
 
+struct RenderPipeline
+{
+	sf::Shader lightShader;
+	sf::Shader normalShader;
+
+	Light light;
+
+	sf::RenderTexture tilemapRender;
+	sf::RenderTexture sceneRender;
+
+	sf::RenderTexture normalRender;
+	sf::RenderTexture pass_normals;
+
+	sf::Texture normal_map;
+	sf::Texture diffuse_map;
+
+	sf::Sprite tilemapRenderSprite;
+};
+
 class ImageHandler : protected View
 {
 public:
+
+#pragma region SHADERS
 	const char lightFrag[897] =
 		"uniform vec2 resolution;"
 		"uniform sampler2D sampler_normal;"
@@ -42,8 +63,9 @@ public:
 		"vec3 normal_map = texture2D(sampler_normal, gl_TexCoord[0].xy).rgb;"
 		"gl_FragColor = vec4(normal_map, 1.0);"
 		"}";
+#pragma endregion
 
-    uint8_t zDepth;
+#pragma region TILEMAPS
     TileMap tileMapA;
     TileMap tileMapB;
     TileMap tileMapC;
@@ -65,38 +87,21 @@ public:
 	TileMap tileMapNormalH;
 	TileMap tileMapNormalI;
 	TileMap tileMapNormalJ;
+#pragma endregion
 
+    uint8_t zDepth;
     sf::Image tileImage;
+	sf::Image tileNormalImage;
     std::vector<TileMap*> tilemapVector;
     std::vector<TileMap*> tilemapNormalVector;
-
-    sf::RenderTexture tilemapRenderBack;//
-    sf::RenderTexture tilemapRenderFront;
-
-	sf::Shader lights_shader;
-	sf::Shader normals_shader_back;
-	sf::Shader normals_shader_front;
-
-	sf::Image tileNormalImage;
-	sf::RenderTexture normalsRenderBack;
-	sf::RenderTexture normalsRenderFront;
-
-	Light light;
-
 	sf::RenderTexture lightRender;
-	sf::RenderTexture pass_normals_back;
-	sf::RenderTexture pass_normals_front;
-	sf::Texture normal_map_back;
-	sf::Texture normal_map_front;
-	sf::Texture diffuse_map_back;
-	sf::Texture diffuse_map_front;
-	//sf::Sprite spriteT;
-	sf::RenderTexture backSceneRender;
-	sf::RenderTexture frontSceneRender;
+	RenderPipeline back;
+	RenderPipeline front;
 
     ImageHandler();
 
     void loadWestKagar();
-	void loadLights();
+	void loadLights(RenderPipeline &scene);
+	void drawScene(RenderPipeline &scene);
     bool checkBounds(int direction, sf::Vector2i position);
 };

--- a/Engine/light.h
+++ b/Engine/light.h
@@ -75,21 +75,26 @@ public:
 
 struct Light
 {
-	Light(
-		sf::Vector3f colorIn = sf::Vector3f(255, 0, 0), 
-		sf::Vector3f positionIn = sf::Vector3f(0, 0, 0.2), 
-		sf::Vector3f attenuationIn = sf::Vector3f(0.5, 0.5, 0.5)) 
+	Light
+	(
+		sf::Vector3f colorIn = sf::Vector3f(255, 205, 140),
+		sf::Vector3f positionIn = sf::Vector3f(0, 0, 0.01),
+		sf::Vector3f falloffIn = sf::Vector3f(0.5, 0.99, 0.55),
+		float ambientIntensityIn = 0.5f
+	) 
 		:
 		color(colorIn),
 		position(positionIn),
-		attenuation(attenuationIn)
+		falloff(falloffIn),
+		ambientIntensity(ambientIntensityIn)
 	{
 		// clamp to [0, 1]
-		if (color.x > 1.0f) { color.x /= 255.0; }
-		if (color.y > 1.0f) { color.y /= 255.0; }
-		if (color.z > 1.0f) { color.z /= 255.0; }
+		while (color.x > 1.0f) { color.x /= 255.0; }
+		while (color.y > 1.0f) { color.y /= 255.0; }
+		while (color.z > 1.0f) { color.z /= 255.0; }
 	}
 	sf::Vector3f color;
 	sf::Vector3f position;
-	sf::Vector3f attenuation;
+	sf::Vector3f falloff;
+	float ambientIntensity;
 };

--- a/Engine/light.h
+++ b/Engine/light.h
@@ -1,0 +1,73 @@
+#pragma once
+#include <SFML/Graphics.hpp>
+#include "constExpressions.h"
+#include "view.h"
+
+class Light : public sf::Drawable, public View
+{
+private:
+	const char m_vertexShader[151] =
+		"void main()"
+		"{"
+			"gl_Position = gl_ModelViewProjectionMatrix * gl_Vertex;"
+			"gl_TexCoord[0] = gl_TextureMatrix[0] * gl_MultiTexCoord0;"
+			"gl_FrontColor = gl_Color;"
+		"}";
+	//TODO: clamp colors for a more pixelly feel.
+	const char m_radialGradient[376] =
+		"uniform vec4 color;"
+		"uniform vec2 center;"
+		"uniform float radius;"
+		"uniform float expand;"
+		"uniform float windowHeight;"
+		"void main(void)"
+		"{"
+			"vec2 centerFromSfml = vec2(center.x, windowHeight - center.y);"
+			"vec2 p = (gl_FragCoord.xy - centerFromSfml) / radius;"
+			"float r = sqrt(dot(p, p));"
+			"if (r < 1.0)"
+			"{"
+				"gl_FragColor = mix(color, gl_Color, (r - expand) / (1 - expand));"
+			"}"
+			"else"
+			"{"
+				"gl_FragColor = gl_Color;"
+			"}"
+		"}";
+	virtual void draw(sf::RenderTarget& target, sf::RenderStates states) const 
+	{
+		//states.transform *= getTransform();
+		states.shader = &shader;
+		target.draw(circle, states);
+	}
+
+public:
+
+	sf::CircleShape circle;
+	sf::Shader shader;
+
+	Light()
+	{
+		//position = pos;
+
+		circle.setRadius(100.f);
+		circle.setOrigin(circle.getRadius(), circle.getRadius());
+		//circle.setPosition(this->getPosition());
+		circle.setFillColor(sf::Color::Transparent);
+
+		shader.loadFromMemory(m_vertexShader, m_radialGradient);
+		shader.setUniform("windowHeight", floatify(View::getScreenSize().y));
+		shader.setUniform("color", sf::Glsl::Vec4(1.f, 1.f, 0.85f, 1.f)); // Blue color hex, normalized
+		shader.setUniform("center", circle.getPosition());
+		shader.setUniform("radius", circle.getRadius());
+		shader.setUniform("expand", 0.f);
+	}
+
+	void setPosition(sf::Vector2f pos, sf::Vector2f worldPos)
+	{
+		circle.setPosition(pos);
+		shader.setUniform("center", worldPos);
+	}
+	//template <typename T>
+	//void setPosition(T const& x, T const& y, sf::RenderWindow &window) { setPosition(pairF(x, y), window); }
+};

--- a/Engine/light.h
+++ b/Engine/light.h
@@ -2,7 +2,7 @@
 #include <SFML/Graphics.hpp>
 #include "constExpressions.h"
 #include "view.h"
-
+/*
 class Light : public sf::Drawable, public View
 {
 private:
@@ -49,18 +49,18 @@ public:
 	Light()
 	{
 		//position = pos;
-
-		circle.setRadius(100.f);
+		circle.setRadius(400.f);
 		circle.setOrigin(circle.getRadius(), circle.getRadius());
 		//circle.setPosition(this->getPosition());
 		circle.setFillColor(sf::Color::Transparent);
 
 		shader.loadFromMemory(m_vertexShader, m_radialGradient);
 		shader.setUniform("windowHeight", floatify(View::getScreenSize().y));
-		shader.setUniform("color", sf::Glsl::Vec4(1.f, 1.f, 0.85f, 1.f)); // Blue color hex, normalized
+		shader.setUniform("color", sf::Glsl::Vec4(1.f, 1.f, 0.85f, 0.4f)); // Blue color hex, normalized
 		shader.setUniform("center", circle.getPosition());
 		shader.setUniform("radius", circle.getRadius());
 		shader.setUniform("expand", 0.f);
+
 	}
 
 	void setPosition(sf::Vector2f pos, sf::Vector2f worldPos)
@@ -70,4 +70,26 @@ public:
 	}
 	//template <typename T>
 	//void setPosition(T const& x, T const& y, sf::RenderWindow &window) { setPosition(pairF(x, y), window); }
+};
+*/
+
+struct Light
+{
+	Light(
+		sf::Vector3f colorIn = sf::Vector3f(255, 0, 0), 
+		sf::Vector3f positionIn = sf::Vector3f(0, 0, 0.2), 
+		sf::Vector3f attenuationIn = sf::Vector3f(0.5, 0.5, 0.5)) 
+		:
+		color(colorIn),
+		position(positionIn),
+		attenuation(attenuationIn)
+	{
+		// clamp to [0, 1]
+		if (color.x > 1.0f) { color.x /= 255.0; }
+		if (color.y > 1.0f) { color.y /= 255.0; }
+		if (color.z > 1.0f) { color.z /= 255.0; }
+	}
+	sf::Vector3f color;
+	sf::Vector3f position;
+	sf::Vector3f attenuation;
 };

--- a/Engine/main.cpp
+++ b/Engine/main.cpp
@@ -118,22 +118,22 @@ int main()
 
 	loadLightTest(window);
 
-	window.setMouseCursorVisible(false);
+	//window.setMouseCursorVisible(false);
     while (window.isOpen())
     {
         window.clear(sf::Color(50, 0, 50, 255));
         window.pollEvents();
 
         //window.drawTileMapsBack();
-		drawLightTest(window);		
+		drawLightTest(window);
 		window.drawSprites();
 		//window.drawLights();
 
 		//window.drawParticles(sf::Color(255, 255, 255, 30)); // quite slow, even when not drawing. fixit.
         //window.drawFlow(cyanRivers);
 
-        //window.drawWaterTile();
-        //window.drawTileMapsFront();
+        window.drawWaterTile();
+        window.drawTileMapsFront();
         //window.drawFullSimplex(sf::Vector2f(-1.f, -0.35f));
 		
 		window.addDevToolsText();

--- a/Engine/main.cpp
+++ b/Engine/main.cpp
@@ -18,9 +18,8 @@ void loadLightTest(Window &window)
 	pass_normals.create(width, height);
 	pass_diffuse.create(width, height);
 
-	//normal_map.loadFromFile("C:/Users/Windows/Desktop/brickwall_normal.jpg");
-	normal_map.loadFromFile("C:/Users/Windows/Desktop/normal_mapping_normal_map.png");
-	diffuse_map.loadFromFile("C:/Users/Windows/Desktop/brickwall.jpg");
+	//normal_map.loadFromFile("C:/Users/Windows/Desktop/normal_mapping_normal_map.png");
+	//diffuse_map.loadFromFile("C:/Users/Windows/Desktop/brickwall.jpg");
 
 	normal_map = window.imageHandler.normalsRender.getTexture();
 	diffuse_map = window.imageHandler.tilemapRenderBack.getTexture();
@@ -31,7 +30,7 @@ void loadLightTest(Window &window)
 	// Center Sprite
 	spriteT.setOrigin(diffuse_map.getSize().x / 2, diffuse_map.getSize().y / 2);
 	spriteT.setPosition(View::getView().getCenter());
-	
+
 }
 void drawLightTest(Window& window)
 {
@@ -45,8 +44,8 @@ void drawLightTest(Window& window)
 	// Clear renderbuffers
 	back.clear();
 	lightRender.clear();
-	pass_diffuse.clear();
-	pass_normals.clear();
+	pass_diffuse.clear(sf::Color(128, 128, 255));
+	pass_normals.clear(sf::Color(128, 128, 255));
 
 	// Diffuse Pass, feed every sprite to draw here before display
 	pass_diffuse.draw(spriteT);
@@ -73,7 +72,6 @@ void drawLightTest(Window& window)
 	window.draw(sf::Sprite(pass_diffuse.getTexture()));
 	// Blend lighting over
 	back.display();
-	
 	window.draw(sf::Sprite(back.getTexture()), sf::BlendMultiply);
 }
 
@@ -154,7 +152,7 @@ int main()
 
 		//window.drawMenu();
 		//window.drawBattle();
-
+		loadLightTest(window);
 		drawLightTest(window);
 
 		window.drawText();

--- a/Engine/main.cpp
+++ b/Engine/main.cpp
@@ -3,64 +3,23 @@
 
 
 // Test Globals
-sf::RenderTexture lightRender, pass_normals, pass_diffuse;
-sf::Texture normal_map, diffuse_map;
-sf::Sprite spriteT;
 
-void loadLightTest(Window &window)
-{
-	int width{ intify(View::getSceneSize().x * View::getPixelSize()) };
-	int height{ intify(View::getSceneSize().y * View::getPixelSize()) };
 
-	//back.create(width, height);
-	lightRender.create(View::getScreenSize().x, View::getScreenSize().y);
-	pass_normals.create(width, height);
-	pass_diffuse.create(width, height);
-
-	//normal_map.loadFromFile("C:/Users/Windows/Desktop/normal_mapping_normal_map.png");
-	//diffuse_map.loadFromFile("C:/Users/Windows/Desktop/brickwall.jpg");
-
-	normal_map = window.imageHandler.normalsRender.getTexture();
-	diffuse_map = window.imageHandler.tilemapRenderBack.getTexture();
-
-	spriteT.setTexture(diffuse_map);
-	spriteT.setScale(pairF(View::getPixelSize(), View::getPixelSize()));
-
-	// Clear to neutral color
-	pass_normals.clear(sf::Color(128, 128, 255));
-	pass_diffuse.clear(sf::Color(128, 128, 255));
-	lightRender.clear();
-
-	// Normals Pass, feed every normal map which should be rendered here
-	// For more then one repeat the next 2 steps before displaying
-	window.imageHandler.normals_shader.setUniform("sampler_normal", normal_map);
-	pass_normals.draw(spriteT, &window.imageHandler.normals_shader);
-	pass_normals.display();
-
-	// Diffuse Pass, feed every sprite to draw here before display
-	pass_diffuse.draw(spriteT);
-	pass_diffuse.display();
-
-	// Light Pass, renders every light into a rendertexture
-	window.imageHandler.lights_shader.setUniform("resolution", sf::Vector2f(View::getScreenSize().x, View::getScreenSize().y));
-	window.imageHandler.lights_shader.setUniform("sampler_normal", pass_normals.getTexture());
-	window.imageHandler.lights_shader.setUniform("sampler_light", lightRender.getTexture());
-	window.imageHandler.lights_shader.setUniform("ambient_intensity", window.imageHandler.light.ambientIntensity);
-	window.imageHandler.lights_shader.setUniform("falloff", window.imageHandler.light.falloff);
-	window.imageHandler.lights_shader.setUniform("light_color", window.imageHandler.light.color);
-}
 void drawLightTest(Window& window)
 {
-	//window.imageHandler.light.position.x = sf::Mouse::getPosition(window).x;
-	//window.imageHandler.light.position.y = View::getScreenSize().y - sf::Mouse::getPosition(window).y;
-	float offset = (TILE_SIZE / 2) * View::getPixelSize();
-	sf::Vector2f charPos = window.getCharacterByOrder(1).sprite.getPosition();
-	window.imageHandler.light.position.x = charPos.x + offset - View::getOriginOffset().x;
-	window.imageHandler.light.position.y = View::getScreenSize().y - charPos.y - offset + View::getOriginOffset().y;
-	
+	window.imageHandler.light.position.x = sf::Mouse::getPosition(window).x;
+	window.imageHandler.light.position.y = View::getScreenSize().y - sf::Mouse::getPosition(window).y;
+	//float offset = (TILE_SIZE / 2) * View::getPixelSize();
+	//sf::Vector2f charPos = window.getCharacterByOrder(1).sprite.getPosition();
+	//window.imageHandler.light.position.x = charPos.x + offset - View::getOriginOffset().x;
+	//window.imageHandler.light.position.y = View::getScreenSize().y - charPos.y - offset + View::getOriginOffset().y;
 	window.imageHandler.lights_shader.setUniform("light_pos", window.imageHandler.light.position);
-	window.draw(sf::Sprite(pass_diffuse.getTexture()), &window.imageHandler.lights_shader);
-	window.draw(sf::Sprite(pass_diffuse.getTexture()), sf::BlendMultiply);
+
+	sf::RenderStates states;
+	states.blendMode = sf::BlendMultiply;
+	states.shader = &window.imageHandler.lights_shader;
+	window.draw(sf::Sprite(window.imageHandler.tilemapRenderBack.getTexture()), states);
+
 }
 
 int main()
@@ -114,28 +73,29 @@ int main()
 	};
 #pragma endregion
 	//window.DEV_TOOLS.toggleFreeMovement();
-	window.setVerticalSyncEnabled(true); // disable to see true, unhindered loop time in ms
-
-	loadLightTest(window);
+	//window.setVerticalSyncEnabled(true); // disable to see true, unhindered loop time in ms
 
 	//window.setMouseCursorVisible(false);
     while (window.isOpen())
     {
         window.clear(sf::Color(50, 0, 50, 255));
         window.pollEvents();
-
-        //window.drawTileMapsBack();
-		drawLightTest(window);
-		window.drawSprites();
-		//window.drawLights();
-
 		//window.drawParticles(sf::Color(255, 255, 255, 30)); // quite slow, even when not drawing. fixit.
         //window.drawFlow(cyanRivers);
 
-        window.drawWaterTile();
+
+
+
+        window.drawTileMapsBack();
+		//window.drawSprites();
+        //window.drawWaterTile();
         window.drawTileMapsFront();
+		drawLightTest(window);
+
+
+
+
         //window.drawFullSimplex(sf::Vector2f(-1.f, -0.35f));
-		
 		window.addDevToolsText();
 		//window.drawText();
 

--- a/Engine/main.cpp
+++ b/Engine/main.cpp
@@ -65,17 +65,19 @@ int main()
 		//window.drawParticles(sf::Color(255, 255, 255, 30)); // quite slow, even when not drawing. fixit.
         //window.drawFlow(cyanRivers);
 
-        window.drawWaterTile();
+        //window.drawWaterTile();
         window.drawTileMapsFront();
-        window.drawFullSimplex(sf::Vector2f(-1.f, -0.35f));
+        //window.drawFullSimplex(sf::Vector2f(-1.f, -0.35f));
 		
-		window.addDevToolsText();
-		window.drawText();
+		//window.addDevToolsText();
+		//window.drawText();
 
-		window.drawMenu();
+		//window.drawMenu();
 		//window.drawBattle();
+
+		window.drawLights();
 
 		window.display();
     }
-    return 0;
+    return EXIT_SUCCESS;
 }

--- a/Engine/main.cpp
+++ b/Engine/main.cpp
@@ -28,8 +28,8 @@ void loadLightTest(Window &window)
 	spriteT.setScale(pairF(View::getPixelSize(), View::getPixelSize()));
 
 	// Center Sprite
-	spriteT.setOrigin(diffuse_map.getSize().x / 2, diffuse_map.getSize().y / 2);
-	spriteT.setPosition(View::getView().getCenter());
+	//spriteT.setOrigin(diffuse_map.getSize().x / 2, diffuse_map.getSize().y / 2);
+	//spriteT.setPosition(View::getView().getCenter());
 
 }
 void drawLightTest(Window& window)
@@ -40,6 +40,10 @@ void drawLightTest(Window& window)
 	// set light position, and adjust for different coordinate systems
 	window.imageHandler.light.position.x = window.mapPixelToCoords(sf::Mouse::getPosition(window)).x;
 	window.imageHandler.light.position.y = height - window.mapPixelToCoords(sf::Mouse::getPosition(window)).y;
+
+	//float offset = (32 / 2) * View::getPixelSize();
+	//window.imageHandler.light.position.x = window.getCharacterByOrder(1).sprite.getPosition().x + offset;
+	//window.imageHandler.light.position.y = height - window.getCharacterByOrder(1).sprite.getPosition().y - offset;
 
 	// Clear renderbuffers
 	back.clear();
@@ -137,6 +141,7 @@ int main()
         window.pollEvents();
 
         //window.drawTileMapsBack();
+		drawLightTest(window);		
 		//window.drawSprites();
 		//window.drawLights();
 
@@ -152,8 +157,6 @@ int main()
 
 		//window.drawMenu();
 		//window.drawBattle();
-		loadLightTest(window);
-		drawLightTest(window);
 
 		window.drawText();
 		window.display();

--- a/Engine/main.cpp
+++ b/Engine/main.cpp
@@ -53,35 +53,26 @@ int main()
 #pragma endregion
 	//window.DEV_TOOLS.toggleFreeMovement();
 	//window.setVerticalSyncEnabled(true); // disable to see true, unhindered loop time in ms
-
 	//window.setMouseCursorVisible(false);
+
+	//window.drawParticles(sf::Color(255, 255, 255, 30)); // quite slow, even when not drawing. fixit.
+    //window.drawFlow(cyanRivers);
+	//window.drawBattle();
+
     while (window.isOpen())
     {
         window.clear(sf::Color(128, 128, 255, 255));
         window.pollEvents();
-		//window.drawParticles(sf::Color(255, 255, 255, 30)); // quite slow, even when not drawing. fixit.
-        //window.drawFlow(cyanRivers);
+		window.addDevToolsText();
 
-
-
-		//window.drawLights();
         window.drawTileMapsBack();
-		window.drawSprites();
+		window.drawCharacterSprites();
         //window.drawWaterTile();
         //window.drawTileMapsFront();
-
-
-
-
-
         //window.drawFullSimplex(sf::Vector2f(-1.f, -0.35f));
-		window.addDevToolsText();
-		//window.drawText();
-
 		//window.drawMenu();
-		//window.drawBattle();
-
 		window.drawText();
+
 		window.display();
     }
     return EXIT_SUCCESS;

--- a/Engine/main.cpp
+++ b/Engine/main.cpp
@@ -67,16 +67,16 @@ int main()
 		//window.drawLights();
         window.drawTileMapsBack();
 		window.drawSprites();
-        window.drawWaterTile();
-        window.drawTileMapsFront();
+        //window.drawWaterTile();
+        //window.drawTileMapsFront();
 
 
 
 
 
-        window.drawFullSimplex(sf::Vector2f(-1.f, -0.35f));
+        //window.drawFullSimplex(sf::Vector2f(-1.f, -0.35f));
 		window.addDevToolsText();
-		window.drawText();
+		//window.drawText();
 
 		//window.drawMenu();
 		//window.drawBattle();

--- a/Engine/main.cpp
+++ b/Engine/main.cpp
@@ -1,6 +1,82 @@
 ﻿#pragma once
 #include "window.h"
 
+
+// Test Globals
+sf::RenderTexture back, lightRender, pass_normals, pass_diffuse;
+sf::Texture normal_map, diffuse_map;
+sf::Sprite spriteT;
+sf::RenderStates renderStates;
+
+void loadLightTest(Window &window)
+{
+	int width{ intify(View::getSceneSize().x * View::getPixelSize()) };
+	int height{ intify(View::getSceneSize().y * View::getPixelSize()) };
+
+	back.create(width, height);
+	lightRender.create(width, height);
+	pass_normals.create(width, height);
+	pass_diffuse.create(width, height);
+
+	//normal_map.loadFromFile("C:/Users/Windows/Desktop/brickwall_normal.jpg");
+	normal_map.loadFromFile("C:/Users/Windows/Desktop/normal_mapping_normal_map.png");
+	diffuse_map.loadFromFile("C:/Users/Windows/Desktop/brickwall.jpg");
+
+	normal_map = window.imageHandler.normalsRender.getTexture();
+	diffuse_map = window.imageHandler.tilemapRenderBack.getTexture();
+
+	spriteT.setTexture(diffuse_map);
+	spriteT.setScale(pairF(View::getPixelSize(), View::getPixelSize()));
+
+	// Center Sprite
+	spriteT.setOrigin(diffuse_map.getSize().x / 2, diffuse_map.getSize().y / 2);
+	spriteT.setPosition(View::getView().getCenter());
+	
+}
+void drawLightTest(Window& window)
+{
+	int width{ intify(View::getSceneSize().x * View::getPixelSize()) };
+	int height{ intify(View::getSceneSize().y * View::getPixelSize()) };
+
+	// set light position, and adjust for different coordinate systems
+	window.imageHandler.light.position.x = window.mapPixelToCoords(sf::Mouse::getPosition(window)).x;
+	window.imageHandler.light.position.y = height - window.mapPixelToCoords(sf::Mouse::getPosition(window)).y;
+
+	// Clear renderbuffers
+	back.clear();
+	lightRender.clear();
+	pass_diffuse.clear();
+	pass_normals.clear();
+
+	// Diffuse Pass, feed every sprite to draw here before display
+	pass_diffuse.draw(spriteT);
+	pass_diffuse.display();
+
+	// Normals Pass, feed every normal map which should be rendered here
+	// For more then one repeat the next 2 steps before displaying
+	window.imageHandler.normals_shader.setUniform("sampler_normal", normal_map);
+	pass_normals.draw(spriteT, &window.imageHandler.normals_shader);
+	pass_normals.display();
+
+	// Light Pass, renders every light into a rendertexture
+	window.imageHandler.lights_shader.setUniform("resolution", sf::Vector2f(width, height));
+	window.imageHandler.lights_shader.setUniform("sampler_normal", pass_normals.getTexture());
+	window.imageHandler.lights_shader.setUniform("sampler_light", lightRender.getTexture());
+
+	window.imageHandler.lights_shader.setUniform("ambient_intensity", window.imageHandler.light.ambientIntensity);
+	window.imageHandler.lights_shader.setUniform("falloff", window.imageHandler.light.falloff);
+	window.imageHandler.lights_shader.setUniform("light_pos", window.imageHandler.light.position);
+	window.imageHandler.lights_shader.setUniform("light_color", window.imageHandler.light.color);
+	back.draw(sf::Sprite(pass_diffuse.getTexture()), &window.imageHandler.lights_shader);
+
+	// Draw diffuse color
+	window.draw(sf::Sprite(pass_diffuse.getTexture()));
+	// Blend lighting over
+	back.display();
+	
+	window.draw(sf::Sprite(back.getTexture()), sf::BlendMultiply);
+}
+
 int main()
 {
     Window window;
@@ -54,31 +130,9 @@ int main()
 	//window.DEV_TOOLS.toggleFreeMovement();
 	//window.setVerticalSyncEnabled(true); // disable to see true, unhindered loop time in ms
 
+	loadLightTest(window);
 
-	int width{ intify(View::getScreenSize().x) };
-	int height{ intify(View::getScreenSize().y) };
-
-	sf::RenderTexture back, lightRender, pass_normals, pass_diffuse;
-	sf::Texture normal_map, diffuse_map;
-
-	back.create(width, height);
-	lightRender.create(width, height);
-	pass_normals.create(width, height);
-	pass_diffuse.create(width, height);
-
-	normal_map.loadFromFile("C:/Users/Windows/Desktop/brickwall_normal.jpg");
-	diffuse_map.loadFromFile("C:/Users/Windows/Desktop/brickwall.jpg");
-
-	sf::Sprite sprite(diffuse_map);
-
-	Light light;
-
-	// Center Sprite
-	sprite.setOrigin(diffuse_map.getSize().x / 2, diffuse_map.getSize().y / 2);
-	sprite.setPosition(View::getView().getCenter());
-
-
-	window.setMouseCursorVisible(false);
+	//window.setMouseCursorVisible(false);
     while (window.isOpen())
     {
         window.clear(sf::Color(50, 0, 50, 255));
@@ -101,41 +155,7 @@ int main()
 		//window.drawMenu();
 		//window.drawBattle();
 
-		// Clear renderbuffers
-		back.clear();
-		lightRender.clear();
-		pass_diffuse.clear();
-		pass_normals.clear();
-
-		// set light position, and adjust for different coordinate systems
-		light.position.x = sf::Mouse::getPosition(window).x;
-		light.position.y = height - sf::Mouse::getPosition(window).y;
-
-		// Diffuse Pass, feed every sprite to draw here before display
-		pass_diffuse.draw(sprite);
-
-		// Normals Pass, feed every normal map which should be rendered here
-		// For more then one repeat the next 2 steps before displaying
-		window.imageHandler.normals_shader.setUniform("sampler_normal", normal_map);
-		pass_normals.draw(sprite, &window.imageHandler.normals_shader);
-
-		// Light Pass, renders every light into a rendertexture
-		window.imageHandler.lights_shader.setUniform("resolution", sf::Vector2f(width, height));
-		window.imageHandler.lights_shader.setUniform("sampler_normal", pass_normals.getTexture());
-		window.imageHandler.lights_shader.setUniform("sampler_light", lightRender.getTexture());
-
-		window.imageHandler.lights_shader.setUniform("ambient_intensity", light.ambientIntensity);
-		window.imageHandler.lights_shader.setUniform("falloff", light.falloff);
-		window.imageHandler.lights_shader.setUniform("light_pos", light.position);
-		window.imageHandler.lights_shader.setUniform("light_color", light.color);
-		back.draw(sf::Sprite(pass_diffuse.getTexture()), &window.imageHandler.lights_shader);
-
-		// Draw diffuse color
-		window.draw(sf::Sprite(pass_diffuse.getTexture()));
-		// Blend lighting over
-		back.display();
-		window.draw(sf::Sprite(back.getTexture()), sf::BlendMultiply);
-
+		drawLightTest(window);
 
 		window.drawText();
 		window.display();

--- a/Engine/main.cpp
+++ b/Engine/main.cpp
@@ -71,58 +71,11 @@ int main()
 
 	sf::Sprite sprite(diffuse_map);
 
-	sf::Shader lights_shader;
-	sf::Shader normals_shader;
-
 	Light light;
-
-	const char lightFrag[] =
-		"uniform vec2 resolution;"
-		"uniform sampler2D sampler_normal;"
-		"uniform sampler2D sampler_light;"
-		"uniform vec3 light_pos;"
-		"uniform vec3 light_color;"
-		"uniform vec3 ambient_color = vec3(0.5, 0.5, 0.5);"
-		"uniform float ambient_intensity;"
-		"uniform vec3 falloff;"
-		"void main()"
-		"{"
-		"vec2 coord = gl_TexCoord[0].xy;"
-		"vec3 normal_map = texture2D(sampler_normal, coord).rgb;"
-		"vec3 light_map = texture2D(sampler_light, coord).rgb;"
-		"vec3 lightDir = vec3((light_pos.xy - gl_FragCoord.xy) / resolution.xy, light_pos.z); "
-		"lightDir.x *= resolution.x / resolution.y;"
-		"float D = length(lightDir);"
-		"vec3 N = normalize(normal_map * 2.0 - 1.0);"
-		//"vec3 N = -1.0 * normalize(normal_map * 2.0 - 1.0);"
-		"vec3 L = normalize(lightDir.xyz);"
-		"vec3 diffuse = light_color.rgb * max(dot(N, L), 0.0);"
-		"vec3 ambient = ambient_color * ambient_intensity;"
-		"float attenuation = 1.0 / (falloff.x + (falloff.y * D) + falloff.z * D * D);"
-		"vec3 intensity = ambient + diffuse * attenuation;"
-		"gl_FragColor = vec4(light_map + intensity, 1.0);"
-		"}";
-
-	const char normalsFrag[] =
-		"uniform sampler2D sampler_normal;"
-		"void main(void)"
-		"{"
-		"vec3 normal_map = texture2D(sampler_normal, gl_TexCoord[0].xy).rgb;"
-		"gl_FragColor = vec4(normal_map, 1.0);"
-		"}";
-
-	lights_shader.loadFromMemory(lightFrag, sf::Shader::Fragment);
-	sf::RenderStates states;
-	states.shader = &lights_shader;
-	states.blendMode = sf::BlendMultiply;
-	normals_shader.loadFromMemory(normalsFrag, sf::Shader::Fragment);
 
 	// Center Sprite
 	sprite.setOrigin(diffuse_map.getSize().x / 2, diffuse_map.getSize().y / 2);
 	sprite.setPosition(View::getView().getCenter());
-
-	// Environmental variables
-
 
 
 	window.setMouseCursorVisible(false);
@@ -163,19 +116,19 @@ int main()
 
 		// Normals Pass, feed every normal map which should be rendered here
 		// For more then one repeat the next 2 steps before displaying
-		normals_shader.setUniform("sampler_normal", normal_map);
-		pass_normals.draw(sprite, &normals_shader);
+		window.imageHandler.normals_shader.setUniform("sampler_normal", normal_map);
+		pass_normals.draw(sprite, &window.imageHandler.normals_shader);
 
 		// Light Pass, renders every light into a rendertexture
-		lights_shader.setUniform("resolution", sf::Vector2f(width, height));
-		lights_shader.setUniform("sampler_normal", pass_normals.getTexture());
-		lights_shader.setUniform("sampler_light", lightRender.getTexture());
+		window.imageHandler.lights_shader.setUniform("resolution", sf::Vector2f(width, height));
+		window.imageHandler.lights_shader.setUniform("sampler_normal", pass_normals.getTexture());
+		window.imageHandler.lights_shader.setUniform("sampler_light", lightRender.getTexture());
 
-		lights_shader.setUniform("ambient_intensity", light.ambientIntensity);
-		lights_shader.setUniform("falloff", light.falloff);
-		lights_shader.setUniform("light_pos", light.position);
-		lights_shader.setUniform("light_color", light.color);
-		back.draw(sf::Sprite(pass_diffuse.getTexture()), &lights_shader);
+		window.imageHandler.lights_shader.setUniform("ambient_intensity", light.ambientIntensity);
+		window.imageHandler.lights_shader.setUniform("falloff", light.falloff);
+		window.imageHandler.lights_shader.setUniform("light_pos", light.position);
+		window.imageHandler.lights_shader.setUniform("light_color", light.color);
+		back.draw(sf::Sprite(pass_diffuse.getTexture()), &window.imageHandler.lights_shader);
 
 		// Draw diffuse color
 		window.draw(sf::Sprite(pass_diffuse.getTexture()));

--- a/Engine/main.cpp
+++ b/Engine/main.cpp
@@ -52,31 +52,154 @@ int main()
 	};
 #pragma endregion
 	//window.DEV_TOOLS.toggleFreeMovement();
-	window.setVerticalSyncEnabled(true); // disable to see true, unhindered loop time in ms
+	//window.setVerticalSyncEnabled(true); // disable to see true, unhindered loop time in ms
 
+
+
+	int width{ intify(View::getScreenSize().x) };
+	int height{ intify(View::getScreenSize().y) };
+
+	std::unique_ptr<sf::RenderTexture> front, back;
+	sf::RenderTexture pass_normals, pass_diffuse;
+	sf::Texture normal_map, diffuse_map;
+
+	front = std::unique_ptr<sf::RenderTexture>(new sf::RenderTexture());
+	back = std::unique_ptr<sf::RenderTexture>(new sf::RenderTexture());
+
+	front->create(width, height);
+	back->create(width, height);
+
+	pass_normals.create(width, height);
+	pass_diffuse.create(width, height);
+
+	normal_map.loadFromFile("C:/Users/Windows/Desktop/brickwall_normal.jpg");
+	diffuse_map.loadFromFile("C:/Users/Windows/Desktop/brickwall.jpg");
+
+	sf::Sprite sprite(diffuse_map);
+
+	sf::Shader lights_shader;
+	sf::Shader normals_shader;
+
+	Light light
+	(
+		sf::Vector3f(255, 214, 170),
+		sf::Vector3f(0, 0, 0.2),
+		sf::Vector3f(0.5, 0.5, 0.5)
+	);
+	Light light2;
+
+	const char lightFrag[] =
+		"uniform vec2 resolution;"
+		"uniform sampler2D sampler_normal;"
+		"uniform sampler2D sampler_light;"
+		"uniform vec3 light_pos;"
+		"uniform vec3 light_color;"
+		"uniform vec3 ambient_color = vec3(0.5, 0.5, 0.5);"
+		"uniform float ambient_intensity = 0.5;"
+		"uniform vec3 falloff;"
+		"void main()"
+		"{"
+		"vec2 coord = gl_TexCoord[0].xy;"
+		"vec3 normal_map = texture2D(sampler_normal, coord).rgb;"
+		"vec3 light_map = texture2D(sampler_light, coord).rgb;"
+		"vec3 lightDir = vec3((light_pos.xy - gl_FragCoord.xy) / resolution.xy, light_pos.z); "
+		"lightDir.x *= resolution.x / resolution.y;"
+		"float D = length(lightDir);"
+		"vec3 N = normalize(normal_map * 2.0 - 1.0);"
+		//"vec3 N = -1.0 * normalize(normal_map * 2.0 - 1.0);"
+		"vec3 L = normalize(lightDir.xyz);"
+		"vec3 diffuse = light_color.rgb * max(dot(N, L), 0.0);"
+		"vec3 ambient = ambient_color * ambient_intensity;"
+		"float attenuation = 1.0 / (falloff.x + (falloff.y * D) + falloff.z * D * D);"
+		"vec3 intensity = ambient + diffuse * attenuation;"
+		"gl_FragColor = vec4(light_map + intensity, 1.0);"
+		"}";
+
+	const char normalsFrag[] =
+		"uniform sampler2D sampler_normal;"
+		"void main(void)"
+		"{"
+		"vec3 normal_map = texture2D(sampler_normal, gl_TexCoord[0].xy).rgb;"
+		"gl_FragColor = vec4(normal_map, 1.0);"
+		"}";
+
+	lights_shader.loadFromMemory(lightFrag, sf::Shader::Fragment);
+	normals_shader.loadFromMemory(normalsFrag, sf::Shader::Fragment);
+
+	// Center Sprite
+	sprite.setOrigin(diffuse_map.getSize().x / 2, diffuse_map.getSize().y / 2);
+	sprite.setPosition(View::getView().getCenter());
+
+	// Environmental variables
+	float ambient_intensity = 0.7;
+	sf::Vector3f falloff(0.5, 0.5, 0.5);
+
+
+	window.setMouseCursorVisible(false);
     while (window.isOpen())
     {
         window.clear(sf::Color(50, 0, 50, 255));
         window.pollEvents();
 
-        window.drawTileMapsBack();
-		window.drawSprites();
+        //window.drawTileMapsBack();
+		//window.drawSprites();
+		//window.drawLights();
 
 		//window.drawParticles(sf::Color(255, 255, 255, 30)); // quite slow, even when not drawing. fixit.
         //window.drawFlow(cyanRivers);
 
         //window.drawWaterTile();
-        window.drawTileMapsFront();
+        //window.drawTileMapsFront();
         //window.drawFullSimplex(sf::Vector2f(-1.f, -0.35f));
 		
-		//window.addDevToolsText();
+		window.addDevToolsText();
 		//window.drawText();
 
 		//window.drawMenu();
 		//window.drawBattle();
 
-		window.drawLights();
+		// Clear renderbuffers
+		back->clear();
+		front->clear();
+		pass_diffuse.clear();
+		pass_normals.clear();
 
+		// set light position, and adjust for different coordinate systems
+		light.position.x = sf::Mouse::getPosition(window).x;
+		light.position.y = height - sf::Mouse::getPosition(window).y;
+
+		// Diffuse Pass, feed every sprite to draw here before display
+		pass_diffuse.draw(sprite);
+		//pass_diffuse.display();
+
+		// Normals Pass, feed every normal map which should be rendered here
+		// For more then one repeat the next 2 steps before displaying
+		normals_shader.setUniform("sampler_normal", normal_map);
+		pass_normals.draw(sprite, &normals_shader);
+		//pass_normals.display();
+
+		// Light Pass, renders every light into a rendertexture
+		lights_shader.setUniform("resolution", sf::Vector2f(width, height));
+		lights_shader.setUniform("sampler_normal", pass_normals.getTexture());
+		lights_shader.setUniform("ambient_intensity", ambient_intensity);
+		lights_shader.setUniform("falloff", falloff);
+
+		// For more lights put the next 6 lines into a loop
+		lights_shader.setUniform("sampler_light", front->getTexture());
+		lights_shader.setUniform("light_pos", light.position);
+		lights_shader.setUniform("light_color", light.color);
+		// draws everything in diffuse rendertexture with lights shader
+		back->draw(sf::Sprite(pass_diffuse.getTexture()), &lights_shader);
+		back->display();
+		std::swap(back, front);
+
+		// Draw diffuse color
+		window.draw(sf::Sprite(pass_diffuse.getTexture()));
+		// Blend lighting over
+		window.draw(sf::Sprite(front->getTexture()), sf::BlendMultiply);
+		// Finally display it
+
+		window.drawText();
 		window.display();
     }
     return EXIT_SUCCESS;

--- a/Engine/main.cpp
+++ b/Engine/main.cpp
@@ -1,27 +1,6 @@
 ﻿#pragma once
 #include "window.h"
 
-
-// Test Globals
-
-
-void drawLightTest(Window& window)
-{
-	window.imageHandler.light.position.x = sf::Mouse::getPosition(window).x;
-	window.imageHandler.light.position.y = View::getScreenSize().y - sf::Mouse::getPosition(window).y;
-	//float offset = (TILE_SIZE / 2) * View::getPixelSize();
-	//sf::Vector2f charPos = window.getCharacterByOrder(1).sprite.getPosition();
-	//window.imageHandler.light.position.x = charPos.x + offset - View::getOriginOffset().x;
-	//window.imageHandler.light.position.y = View::getScreenSize().y - charPos.y - offset + View::getOriginOffset().y;
-	window.imageHandler.lights_shader.setUniform("light_pos", window.imageHandler.light.position);
-
-	sf::RenderStates states;
-	states.blendMode = sf::BlendMultiply;
-	states.shader = &window.imageHandler.lights_shader;
-	window.draw(sf::Sprite(window.imageHandler.tilemapRenderBack.getTexture()), states);
-
-}
-
 int main()
 {
     Window window;
@@ -78,26 +57,26 @@ int main()
 	//window.setMouseCursorVisible(false);
     while (window.isOpen())
     {
-        window.clear(sf::Color(50, 0, 50, 255));
+        window.clear(sf::Color(128, 128, 255, 255));
         window.pollEvents();
 		//window.drawParticles(sf::Color(255, 255, 255, 30)); // quite slow, even when not drawing. fixit.
         //window.drawFlow(cyanRivers);
 
 
 
-
+		//window.drawLights();
         window.drawTileMapsBack();
-		//window.drawSprites();
-        //window.drawWaterTile();
+		window.drawSprites();
+        window.drawWaterTile();
         window.drawTileMapsFront();
-		drawLightTest(window);
 
 
 
 
-        //window.drawFullSimplex(sf::Vector2f(-1.f, -0.35f));
+
+        window.drawFullSimplex(sf::Vector2f(-1.f, -0.35f));
 		window.addDevToolsText();
-		//window.drawText();
+		window.drawText();
 
 		//window.drawMenu();
 		//window.drawBattle();

--- a/Engine/textbox.h
+++ b/Engine/textbox.h
@@ -93,7 +93,7 @@ public:
 	void emptyContainers()
 	{
 		box.emptyContainers();
-		fontContainer.clear();
+		if (!fontContainer.empty()) { fontContainer.clear(); }
 	}
 	void addText(std::string string, sf::Vector2f startPosition, int scale, int boundingWidth, bool background, bool borders)
 	{

--- a/Engine/view.h
+++ b/Engine/view.h
@@ -24,7 +24,7 @@ private:
 		else if (m_screenSize.x < CHUNK_WIDTH_PIXELS * (factor * 4)) { m_pixelSize = 4; }
 		else { m_pixelSize = 4; }
 		// I doubt we need more.
-		m_pixelSize = 1;
+		m_pixelSize = 2;
 
 		//DEBUG(m_pixelSize);
 		m_tilePixels = TILE_SIZE * m_pixelSize;

--- a/Engine/view.h
+++ b/Engine/view.h
@@ -23,6 +23,7 @@ private:
 		else if (m_screenSize.x < CHUNK_WIDTH_PIXELS * (factor * 4)) { m_pixelSize = 4; }
 		else { m_pixelSize = 4; }
 		// I doubt we need more.
+		m_pixelSize = 1;
 
 		//DEBUG(m_pixelSize);
 		m_tilePixels = TILE_SIZE * m_pixelSize;

--- a/Engine/view.h
+++ b/Engine/view.h
@@ -9,9 +9,10 @@ private:
 	inline static sf::Vector2u m_screenSize;
 	inline static sf::Vector2i m_uniqueScreenSizeGridSize;
 	inline static sf::Vector2u m_sceneSize;
+	inline static sf::Vector2f m_originOffset;
 	inline static int m_pixelSize;
 	inline static int m_tilePixels;
-
+	
 	sf::Vector2f m_movementOffset;
 	bool m_movementAllowed;
 
@@ -39,11 +40,24 @@ private:
 
 		//new stuff to fixs bugs...
 		m_view.setSize(floatify(m_uniqueScreenSizeGridSize.x * m_tilePixels), floatify(m_uniqueScreenSizeGridSize.y * m_tilePixels));
-		m_view.setCenter(floatify(m_view.getSize().x / 2), floatify(m_view.getSize().y / 2));
+		m_view.setCenter(pairF(m_view.getSize().x / 2, m_view.getSize().y / 2));
+		m_originOffset = pairF(0.f, 0.f);
 	}
 	void m_setSceneSize()
 	{
 		m_sceneSize = sf::Vector2u(32 * TILES_PER_CHUNK_X * 3, 32 * TILES_PER_CHUNK_Y * 3);
+	}
+
+	void m_move(sf::Vector2f offset)
+	{
+		m_originOffset += offset;
+		m_view.move(offset);
+	}
+	void m_move(float offsetX, float offsetY)
+	{
+		m_originOffset.x += offsetX;
+		m_originOffset.y += offsetY;
+		m_view.move(offsetX, offsetY);
 	}
 
 public:
@@ -61,6 +75,7 @@ public:
 	static const sf::View getView() { return m_view; }
 	static const int getTilePixels() { return m_tilePixels; }
 	static const sf::Vector2u getSceneSize() { return m_sceneSize; }
+	static const sf::Vector2f getOriginOffset() { return m_originOffset; }
 	sf::Vector2f getViewCoordinates(int dir)
 	{
 		switch (dir)
@@ -112,7 +127,7 @@ public:
 		{
 			if (getViewCoordinates(UR).x < m_sceneSize.x * m_pixelSize)
 			{
-				m_view.move(floatify(stepSize * m_pixelSize), 0.f);
+				m_move(floatify(stepSize * m_pixelSize), 0.f);
 				return m_view;
 			}
 		}
@@ -120,7 +135,7 @@ public:
 		{
 			if (getViewCoordinates(UL).x > m_pixelSize)
 			{
-				m_view.move(floatify(-stepSize * m_pixelSize), 0.f);
+				m_move(floatify(-stepSize * m_pixelSize), 0.f);
 				return m_view;
 			}
 		}
@@ -128,7 +143,7 @@ public:
 		{
 			if (getViewCoordinates(DL).y < m_sceneSize.y * m_pixelSize)
 			{
-				m_view.move(0.f, floatify(stepSize * m_pixelSize));
+				m_move(0.f, floatify(stepSize * m_pixelSize));
 				return m_view;
 			}
 		}
@@ -136,7 +151,7 @@ public:
 		{
 			if (getViewCoordinates(UL).y > m_pixelSize)
 			{
-				m_view.move(0.f, floatify(-stepSize * m_pixelSize));
+				m_move(0.f, floatify(-stepSize * m_pixelSize));
 				return m_view;
 			}
 		}

--- a/Engine/water.h
+++ b/Engine/water.h
@@ -40,8 +40,8 @@ public:
 
 	Water()
 	{
-		noise.m_simplexSizeX = 32;
-		noise.m_simplexSizeY = 32;
+		noise.m_simplexSizeX = TILE_SIZE;
+		noise.m_simplexSizeY = TILE_SIZE;
 		width = noise.m_simplexSizeX;
 		height = noise.m_simplexSizeY;
 

--- a/Engine/window.cpp
+++ b/Engine/window.cpp
@@ -672,16 +672,16 @@ void Window::drawWaterTile()
 // Text Functions
 void Window::addDevToolsText()
 {
-	std::string longString{ "But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the masterbuilder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful." }; 
+	//std::string longString{ "But I must explain to you how all this mistaken idea of denouncing pleasure and praising pain was born and I will give you a complete account of the system, and expound the actual teachings of the great explorer of the truth, the masterbuilder of human happiness. No one rejects, dislikes, or avoids pleasure itself, because it is pleasure, but because those who do not know how to pursue pleasure rationally encounter consequences that are extremely painful." }; 
 	//std::string longString{ "I want nachos. They will be made. I will put cheese on them because that's what makes nachos nachos. NACHOS. What else do you want on them? Onions? No onions. No veggies. Only quiche, yams, and meaty nachos." };
 	//std::string longString{ "Hey! How's it going? Let's test these chars! Oh yeah! Hello, allowed, initiate..." };
-	textBox.box.setColor(sf::Color::Black);
-	textBox.box.setAlpha(150);
-	addText(longString, pairF(250, 250), 1, 800);
+	//textBox.box.setColor(sf::Color::Black);
+	//textBox.box.setAlpha(150);
+	//addText(longString, pairF(250, 250), 1, 800);
 
 	int devToolsTextSize{ 2 };
 	addText("FPS: " + this->DEV_TOOLS.getFPS(), getViewCoordinates(UL), devToolsTextSize, 0, true, true, true);
-	addText("LASTY", getViewCoordinates(DR), devToolsTextSize, 0, true, true, true);
+	//addText("LASTY", getViewCoordinates(DR), devToolsTextSize, 0, true, true, true);
 	addText("X: " + stringify(getGridPosition().x) + ", Y :" + stringify(getGridPosition().y), getViewCoordinates(UR), devToolsTextSize, 0, true, true, true);
 	if (this->DEV_TOOLS.wallToggleBool) { addText("NO WALLS", getViewCoordinates(DL), devToolsTextSize, 0, true, true, true); }
 }
@@ -742,10 +742,19 @@ void Window::drawMenu()
 // Light Functions
 void Window::drawLights()
 {
-	//sf::Vector2f pos(500.f, 500.f);
-	sf::Vector2f pos(pairF(sf::Mouse::getPosition().x, sf::Mouse::getPosition().y));
 
-	sf::Vector2f worldPos(pairF(mapCoordsToPixel(pos).x, mapCoordsToPixel(pos).y));
-	light.setPosition(pos, worldPos);
-	draw(light);
+}
+
+// Test Functions
+// Globals
+
+
+void Window::makeTest()
+{
+
+}
+
+void Window::drawTest()
+{
+
 }

--- a/Engine/window.cpp
+++ b/Engine/window.cpp
@@ -659,7 +659,7 @@ void Window::drawWaterTile()
 			if (water.westKagarWater[i + j * (TILES_PER_CHUNK_X * 4)])
 			{
 				water.noise.noise.setPosition(water.width * pixelSize * i, water.height * pixelSize * j);
-				draw(water.noise.noise);
+				draw(water.noise.noise, sf::BlendMultiply); // pretty cool with the blend multiply
 			}
 		}
 	}

--- a/Engine/window.cpp
+++ b/Engine/window.cpp
@@ -176,8 +176,8 @@ void Window::pollEvents()
 }
 
 // Tilemap Functions
-void Window::drawTileMapsBack() { this->draw(imageHandler.tilemapWindowBack); }
-void Window::drawTileMapsFront() { this->draw(imageHandler.tilemapWindowFront); }
+void Window::drawTileMapsBack() { this->draw(sf::Sprite(imageHandler.tilemapRenderBack.getTexture())); }
+void Window::drawTileMapsFront() { this->draw(sf::Sprite(imageHandler.tilemapRenderFront.getTexture())); }
 
 // Sprite Functions
 void Window::sortSpriteVectorByHeight()

--- a/Engine/window.cpp
+++ b/Engine/window.cpp
@@ -175,10 +175,9 @@ void Window::pollEvents()
 	if (!menu.menuEnabled()) { pollMovement(); }
 }
 
-// Tilemap Functions
-void Window::drawTileMapsBack()
+// Tilemap and Lighting Functions
+void Window::assignLightToCharacterPosition(Light &light, sf::Shader &lightShader)
 {
-
 	//imageHandler.light.position.x = sf::Mouse::getPosition().x;
 	//imageHandler.light.position.y = View::getSceneSize().y - sf::Mouse::getPosition().y;
 	float offset = (TILE_SIZE / 2);
@@ -187,52 +186,35 @@ void Window::drawTileMapsBack()
 		getCharacterByOrder(1).sprite.getPosition().x / View::getPixelSize() + offset,
 		View::getSceneSize().y - (getCharacterByOrder(1).sprite.getPosition().y / View::getPixelSize()) - offset
 	);
-	imageHandler.light.position.x = charPos.x;
-	imageHandler.light.position.y = charPos.y;
-	imageHandler.lights_shader.setUniform("light_pos", imageHandler.light.position);
+	light.position.x = charPos.x;
+	light.position.y = charPos.y;
+	lightShader.setUniform("light_pos", light.position);
+}
+void Window::drawTileMapsBack()
+{
+	// Assigns a light to the lead character
+	assignLightToCharacterPosition(imageHandler.back.light, imageHandler.back.lightShader);
 
-	imageHandler.lights_shader.setUniform("sampler_normal", imageHandler.pass_normals_back.getTexture());
-	imageHandler.backSceneRender.draw(sf::Sprite(imageHandler.tilemapRenderBack.getTexture()));
+	// Draws diffuse scene and lights, blended
+	imageHandler.drawScene(imageHandler.back);
 
-	sf::RenderStates states;
-	states.blendMode = sf::BlendMultiply;
-	states.shader = &imageHandler.lights_shader;
-	//states.transform.scale(pairF(View::getPixelSize(), View::getPixelSize()));
-	imageHandler.backSceneRender.draw(sf::Sprite(imageHandler.tilemapRenderBack.getTexture()), states);
-
-	sf::RenderStates states2;
-	states2.transform.scale(pairF(View::getPixelSize(), View::getPixelSize()));
-	imageHandler.backSceneRender.display();
-	this->draw(sf::Sprite(imageHandler.backSceneRender.getTexture()), states2);
+	// Scale the scene, display it, and draw it to the window
+	sf::RenderStates windowStates;
+	windowStates.transform.scale(pairF(View::getPixelSize(), View::getPixelSize()));
+	this->draw(sf::Sprite(imageHandler.back.sceneRender.getTexture()), windowStates);
 }
 void Window::drawTileMapsFront()
 {
+	// Assigns a light to the lead character
+	assignLightToCharacterPosition(imageHandler.front.light, imageHandler.front.lightShader);
 
-	//imageHandler.light.position.x = sf::Mouse::getPosition().x;
-	//imageHandler.light.position.y = View::getSceneSize().y - sf::Mouse::getPosition().y;
-	float offset = (TILE_SIZE / 2);
-	sf::Vector2f charPos = pairF
-	(
-		getCharacterByOrder(1).sprite.getPosition().x / View::getPixelSize() + offset,
-		View::getSceneSize().y - (getCharacterByOrder(1).sprite.getPosition().y / View::getPixelSize()) - offset
-	);
-	imageHandler.light.position.x = charPos.x;
-	imageHandler.light.position.y = charPos.y;
-	imageHandler.lights_shader.setUniform("light_pos", imageHandler.light.position);
+	// Draws diffuse scene and lights, blended
+	imageHandler.drawScene(imageHandler.front);
 
-	imageHandler.lights_shader.setUniform("sampler_normal", imageHandler.pass_normals_front.getTexture());
-	imageHandler.frontSceneRender.draw(sf::Sprite(imageHandler.tilemapRenderFront.getTexture()));
-
-	sf::RenderStates states;
-	states.blendMode = sf::BlendMultiply;
-	states.shader = &imageHandler.lights_shader;
-	//states.transform.scale(pairF(View::getPixelSize(), View::getPixelSize()));
-	imageHandler.frontSceneRender.draw(sf::Sprite(imageHandler.tilemapRenderFront.getTexture()), states);
-
-	sf::RenderStates states2;
-	states2.transform.scale(pairF(View::getPixelSize(), View::getPixelSize()));
-	imageHandler.frontSceneRender.display();
-	this->draw(sf::Sprite(imageHandler.frontSceneRender.getTexture()), states2);
+	// Scale the scene, display it, and draw it to the window
+	sf::RenderStates windowStates;
+	windowStates.transform.scale(pairF(View::getPixelSize(), View::getPixelSize()));
+	this->draw(sf::Sprite(imageHandler.front.sceneRender.getTexture()), windowStates);
 }
 
 // Sprite Functions
@@ -795,5 +777,3 @@ void Window::drawMenu()
 
 	}
 }
-
-// Light Functions

--- a/Engine/window.cpp
+++ b/Engine/window.cpp
@@ -176,8 +176,64 @@ void Window::pollEvents()
 }
 
 // Tilemap Functions
-void Window::drawTileMapsBack() { this->draw(sf::Sprite(imageHandler.tilemapRenderBack.getTexture())); }
-void Window::drawTileMapsFront() { this->draw(sf::Sprite(imageHandler.tilemapRenderFront.getTexture())); }
+void Window::drawTileMapsBack()
+{
+
+	//imageHandler.light.position.x = sf::Mouse::getPosition().x;
+	//imageHandler.light.position.y = View::getSceneSize().y - sf::Mouse::getPosition().y;
+	float offset = (TILE_SIZE / 2);
+	sf::Vector2f charPos = pairF
+	(
+		getCharacterByOrder(1).sprite.getPosition().x / View::getPixelSize() + offset,
+		View::getSceneSize().y - (getCharacterByOrder(1).sprite.getPosition().y / View::getPixelSize()) - offset
+	);
+	imageHandler.light.position.x = charPos.x;
+	imageHandler.light.position.y = charPos.y;
+	imageHandler.lights_shader.setUniform("light_pos", imageHandler.light.position);
+
+	imageHandler.lights_shader.setUniform("sampler_normal", imageHandler.pass_normals_back.getTexture());
+	imageHandler.backSceneRender.draw(sf::Sprite(imageHandler.tilemapRenderBack.getTexture()));
+
+	sf::RenderStates states;
+	states.blendMode = sf::BlendMultiply;
+	states.shader = &imageHandler.lights_shader;
+	//states.transform.scale(pairF(View::getPixelSize(), View::getPixelSize()));
+	imageHandler.backSceneRender.draw(sf::Sprite(imageHandler.tilemapRenderBack.getTexture()), states);
+
+	sf::RenderStates states2;
+	states2.transform.scale(pairF(View::getPixelSize(), View::getPixelSize()));
+	imageHandler.backSceneRender.display();
+	this->draw(sf::Sprite(imageHandler.backSceneRender.getTexture()), states2);
+}
+void Window::drawTileMapsFront()
+{
+
+	//imageHandler.light.position.x = sf::Mouse::getPosition().x;
+	//imageHandler.light.position.y = View::getSceneSize().y - sf::Mouse::getPosition().y;
+	float offset = (TILE_SIZE / 2);
+	sf::Vector2f charPos = pairF
+	(
+		getCharacterByOrder(1).sprite.getPosition().x / View::getPixelSize() + offset,
+		View::getSceneSize().y - (getCharacterByOrder(1).sprite.getPosition().y / View::getPixelSize()) - offset
+	);
+	imageHandler.light.position.x = charPos.x;
+	imageHandler.light.position.y = charPos.y;
+	imageHandler.lights_shader.setUniform("light_pos", imageHandler.light.position);
+
+	imageHandler.lights_shader.setUniform("sampler_normal", imageHandler.pass_normals_front.getTexture());
+	imageHandler.frontSceneRender.draw(sf::Sprite(imageHandler.tilemapRenderFront.getTexture()));
+
+	sf::RenderStates states;
+	states.blendMode = sf::BlendMultiply;
+	states.shader = &imageHandler.lights_shader;
+	//states.transform.scale(pairF(View::getPixelSize(), View::getPixelSize()));
+	imageHandler.frontSceneRender.draw(sf::Sprite(imageHandler.tilemapRenderFront.getTexture()), states);
+
+	sf::RenderStates states2;
+	states2.transform.scale(pairF(View::getPixelSize(), View::getPixelSize()));
+	imageHandler.frontSceneRender.display();
+	this->draw(sf::Sprite(imageHandler.frontSceneRender.getTexture()), states2);
+}
 
 // Sprite Functions
 void Window::sortSpriteVectorByHeight()
@@ -642,8 +698,9 @@ void Window::drawFlow()
 void Window::drawWaterTile()
 {
 	// get values from View class
-	int pixelSize{ getPixelSize() };
+	int pixelSize{ View::getPixelSize() };
 	water.noise.noise.setScale(pixelSize, pixelSize);
+
 	// Is automatic, prints on tiles 89 and 90.
 	if (!menu.menuEnabled()) { water.update(); }
 
@@ -740,21 +797,3 @@ void Window::drawMenu()
 }
 
 // Light Functions
-void Window::drawLights()
-{
-
-}
-
-// Test Functions
-// Globals
-
-
-void Window::makeTest()
-{
-
-}
-
-void Window::drawTest()
-{
-
-}

--- a/Engine/window.cpp
+++ b/Engine/window.cpp
@@ -405,7 +405,7 @@ void Window::checkUnderlyingTile()
 		int y{ intify(getCharacterByOrder(i).sprite.getPosition().y / (getTilePixels())) };
 		int arrayPos{ intify((TILES_PER_CHUNK_X * 4) * y + x) };
 
-		if (water.westKagarWater[arrayPos] && getCharacterByOrder(i).spriteColour != SpriteColor::Blue)
+		if (water.westKagarWater[arrayPos])
 		{
 			getCharacterByOrder(i).spriteColour = SpriteColor::Blue;
 			getCharacterByOrder(i).textureUpdate();

--- a/Engine/window.cpp
+++ b/Engine/window.cpp
@@ -738,3 +738,14 @@ void Window::drawMenu()
 
 	}
 }
+
+// Light Functions
+void Window::drawLights()
+{
+	//sf::Vector2f pos(500.f, 500.f);
+	sf::Vector2f pos(pairF(sf::Mouse::getPosition().x, sf::Mouse::getPosition().y));
+
+	sf::Vector2f worldPos(pairF(mapCoordsToPixel(pos).x, mapCoordsToPixel(pos).y));
+	light.setPosition(pos, worldPos);
+	draw(light);
+}

--- a/Engine/window.h
+++ b/Engine/window.h
@@ -14,6 +14,7 @@
 #include "water.h"
 #include "maps.h"
 #include "textbox.h"
+#include "light.h"
 
 class Window : public sf::RenderWindow, public Noise, public View
 {
@@ -53,6 +54,7 @@ public:
 	TextBox textBox;
 	TextBox importantTextBox;
 	Menu menu;
+	Light light;
 
 	// Screenshot
 	bool onlyOnceHack{ true };
@@ -99,4 +101,5 @@ public:
 	void moveCharacters();
 	void addDevToolsText();
 	//void initWaterTile();
+	void drawLights();
 };

--- a/Engine/window.h
+++ b/Engine/window.h
@@ -70,7 +70,7 @@ public:
 	void drawFlow();
 	void drawParticles();
 	void drawParticles(sf::Color color);
-	void drawSprites();
+	void drawCharacterSprites();
 	void drawWaterTile();
 	void drawTileMapsFront();
 	void drawFullSimplex(sf::Vector2f direction = sf::Vector2f(0.f, 0.f));
@@ -91,7 +91,7 @@ public:
 	void m_groupDraw(int dirX, int dirY);
 	void m_groupDraw();
 
-	sf::Vector2i getGridPosition();
+	sf::Vector2i getCharacterGridPosition();
 	void changeFalseLastKeyState(bool& lastKeyInput);
 	void sortSpriteVectorByHeight();
 	void setPositionAndDraw(float x, float y);
@@ -100,6 +100,5 @@ public:
 
 	void moveCharacters();
 	void addDevToolsText();
-	//void initWaterTile();
-	//void drawLights();
+
 };

--- a/Engine/window.h
+++ b/Engine/window.h
@@ -100,7 +100,5 @@ public:
 	void moveCharacters();
 	void addDevToolsText();
 	//void initWaterTile();
-	void drawLights();
-	void drawTest();
-	void makeTest();
+	//void drawLights();
 };

--- a/Engine/window.h
+++ b/Engine/window.h
@@ -65,6 +65,7 @@ public:
 	void pollMovement();
 
 	void drawTileMapsBack();
+	void assignLightToCharacterPosition(Light& light, sf::Shader &lightShader);
 	void drawFlow(FlowPreset& fp);
 	void drawFlow();
 	void drawParticles();

--- a/Engine/window.h
+++ b/Engine/window.h
@@ -54,7 +54,6 @@ public:
 	TextBox textBox;
 	TextBox importantTextBox;
 	Menu menu;
-	Light light;
 
 	// Screenshot
 	bool onlyOnceHack{ true };
@@ -102,4 +101,6 @@ public:
 	void addDevToolsText();
 	//void initWaterTile();
 	void drawLights();
+	void drawTest();
+	void makeTest();
 };


### PR DESCRIPTION
Implemented normal maps and lights with shaders. Runs, but slowly. Moving on to a refactor to search for unnecessary draw calls and texture resets.

This is the first draft and will be looked at later with a fresh set of eyes.

The draw calls to the window are such that the character sprites have to be drawn between layers of tilemaps. The lighting and tilemap renders have been split into two - before and after sprites - since the tilemaps have to blend textures with diffuse and shader renders, but not with sprites.

I should write more but I'm yawning and a solo dev.